### PR TITLE
Assign fix in codegen

### DIFF
--- a/src/backend/codegen.ml
+++ b/src/backend/codegen.ml
@@ -74,6 +74,7 @@ let translate (namespaces, globals, functions) =
                     )
       | A.Id str -> L.const_int i32_t 0
       | A.Binop (expr, binop, expr2) -> L.const_int i32_t 0
+      | A.Assign (expr, expr2) -> L.const_int i32_t 0 (* Create a local var if not string *)
       | A.Call (func, [expr]) -> (match func with
                                   | None -> L.const_int i32_t 0
                                   | Some y -> (match y with 

--- a/src/frontend/ast.mli
+++ b/src/frontend/ast.mli
@@ -21,7 +21,7 @@ type fn_typ =
 
 type bin_op =
   | Add | Sub | Mul | Div | Mod | Exp
-  | Asn | AddAsn | SubAsn | MulAsn | DivAsn | ModAsn | ExpAsn
+  | Asn
   | Eq | Lt | Gt | Neq | Leq | Geq
   | LogAnd | LogOr
   | Filter | Map

--- a/src/frontend/ast.mli
+++ b/src/frontend/ast.mli
@@ -54,6 +54,7 @@ and expr =
   | Lit of lit
   | Id of string
   | Binop of expr * bin_op * expr
+  | Assign of expr * expr
   | Call of string option * expr list
   | Uniop of un_op * expr
   | Cond of expr * expr * expr (* technically Ternop *)

--- a/src/frontend/astprint.ml
+++ b/src/frontend/astprint.ml
@@ -32,9 +32,9 @@ let string_of_fn_typ = function
 type op_typ = Infix | Prefix | PostfixPair
 
 let _fix = function
+  | Asn
   | Add | Sub | Mul | Div | Mod | Exp 
   | Eq | Lt | Gt | Neq | Leq | Geq | LogAnd | LogOr
-  | Asn | AddAsn | SubAsn | MulAsn | DivAsn | ModAsn | ExpAsn
   | Filter | Map | Lookback | Access -> Infix
   | For | Do -> Prefix
   | Index -> PostfixPair
@@ -48,7 +48,7 @@ let string_of_binop = function
   | Exp  -> " ^ "
   | Eq -> " == "
   | Lt -> " < "
-  | Gt -> " >"
+  | Gt -> " > "
   | Neq -> " != "
   | Leq -> " <= "
   | Geq -> " >= "
@@ -59,12 +59,6 @@ let string_of_binop = function
   | For -> "for "
   | Do -> "do "
   | Asn -> " = "
-  | AddAsn -> " += "
-  | SubAsn -> " -= "
-  | MulAsn -> " *= "
-  | DivAsn -> " /= "
-  | ModAsn -> " %= "
-  | ExpAsn -> " ^= "
   | Lookback -> ".."
   | Access -> "."
   | _ -> "" (* should raise error *)
@@ -123,6 +117,7 @@ and string_of_expr = function
  | Lit l -> string_of_lit l
  | Id s -> s
  | Uniop(o, e) -> string_of_uniop_expr string_of_expr o e
+ | Assign(l, r) -> string_of_binop_expr string_of_expr l Asn r
  | Binop(e1, o, e2) -> string_of_binop_expr string_of_expr e1 o e2
  | Call(s, el) -> string_of_opt_default "_" nop s ^ 
                   string_of_list string_of_expr el "(" ", " ")" (is_some s)

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -101,7 +101,8 @@ expr:
   | asn_expr                                { $1 } 
 
 asn_expr:
-  | unary_expr asn_op asn_expr              { Binop ($1, $2, $3) }
+  | unary_expr ASSIGN asn_expr              { Assign($1, $3) }
+  | unary_expr asn_op asn_expr              { Assign($1, Binop ($1, $2, $3)) }
   | if_expr                                 { $1 } 
 
 if_expr:
@@ -213,13 +214,12 @@ actual_list:
 
 /* operator rules */
 asn_op:
-  | ASSIGN                                  { Asn } 
-  | ADD_ASN                                 { AddAsn }
-  | SUB_ASN                                 { SubAsn }
-  | MUL_ASN                                 { MulAsn }
-  | DIV_ASN                                 { DivAsn }
-  | MOD_ASN                                 { ModAsn }
-  | EXP_ASN                                 { ExpAsn }
+  | ADD_ASN                                 { Add }
+  | SUB_ASN                                 { Sub }
+  | MUL_ASN                                 { Mul }
+  | DIV_ASN                                 { Div }
+  | MOD_ASN                                 { Mod }
+  | EXP_ASN                                 { Exp }
 
 eq_op:
   | EQ                                      { Eq }


### PR DESCRIPTION
@j-hui changed our def for var assignment bindings,
now reflected in codegen expr matching.