### PR TITLE
added alias field to externs for namespace flattening

### DIFF
--- a/src/frontend/ast.mli
+++ b/src/frontend/ast.mli
@@ -78,9 +78,10 @@ type struct_def = {
 }
 
 type extern_decl = {
-  exfname     : string;
-  exret_typ   : typ option;
-  exformals   : bind list;
+  xalias    : string; (* what we call inside shux *)
+  xfname    : string; (* what we link to outside shux *)
+  xret_typ  : typ option;
+  xformals  : bind list;
 }
 
 type let_decl =

--- a/src/frontend/astprint.ml
+++ b/src/frontend/astprint.ml
@@ -139,8 +139,8 @@ let string_of_fdecl = function { fn_typ = fn; fname = id; formals = fs;
 let string_of_struct_def = function { sname = n; fields = f } ->
   "struct " ^ n ^ string_of_list string_of_bind f "{\n\t" ";\n\t" "}" true
 
-let string_of_extern = function { exfname = n; exformals = f; exret_typ = r } ->
-  "extern " ^ n ^ string_of_list string_of_bind f "(" ", " ")" true ^ string_of_typ r ^ ";"
+let string_of_extern = function { xalias = a; xfname = n; xformals = f; xret_typ = r } ->
+  "extern " ^ a ^ string_of_list string_of_bind f "(" ", " ")" true ^ string_of_typ r ^ ";"
 
 let string_of_let = function
   | LetDecl(bind, expr) -> string_of_bind bind ^ " " ^ string_of_expr expr ^ ";"

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -52,8 +52,8 @@ let_decl:
   | LET typ ID ASSIGN expr SEMI             { LetDecl((Bind(Immutable, $2, $3), $5)) }
   | STRUCT ID LBRACE struct_def RBRACE      { StructDef({sname = $2; fields = List.rev $4}) }
   | EXTERN ID LPAREN formals RPAREN 
-    ret_typ SEMI                            { ExternDecl({exfname = $2; exret_typ = $6;
-                                              exformals = $4;}) }
+    ret_typ SEMI                            { ExternDecl({xalias = $2; xfname = $2; 
+                                              xret_typ = $6; xformals = $4;}) }
 
 struct_def:
   | struct_def val_decl SEMI                { $2::$1 }


### PR DESCRIPTION
I foresee us later needing to flatten our namespace by doing some stuff like:
```
ns io {
    extern print(string s);
}
kn print(string s) {
...
}
```
into
```
extern io_print(string s);
print(string s) {
...
}
```
However we must preserve what `io_print()` is meant to link to. So, we introduce the idea of an alias, such that the `xalias` is what we call from inside shux (which we can mangle all we want for namespacing etc.), but the `xfname` is preserved throughout namespace transformations so we have a handle of what to link to. 