### PR TITLE
fix to formals

### DIFF
--- a/src/backend/cast.mli
+++ b/src/backend/cast.mli
@@ -1,18 +1,3 @@
-(* cast.ml *) 
-(* Makes most sense to implement this ground-up *) 
-
-(* I am also going to use just regular names...
-   unsure how OCaml handles name type conflicts *) 
-
-(* Generator *) 
-(*
-type buffer = typ * int
-
-type gn_struct = buffer list
-
-type gn = Gn of gn_struct * kn
-*)
-
 type ctyp = Sast.styp
 
 type cbind = Sast.sbind
@@ -31,9 +16,7 @@ type clit =
   | CLitBool of bool
   | CLitStr of string
   | CLitArray of cexpr list
-  | CLitStruct of cstruct_field list
-
-and cstruct_field = CStructField of string * cexpr
+  | CLitStruct of (string * cexpr) list
 
 and cexpr =
   | CLit of ctyp * clit
@@ -44,7 +27,18 @@ and cexpr =
   | CUnop of ctyp * cun_op * cexpr
   | CCond of ctyp * cexpr * cexpr * cexpr
 
-type cfn_decl = Sast.sfn_decl
+type cstmt =
+  | CBlock of cexpr list
+  | CLoop of cexpr (* int *) * cstmt
+  | CReturn of cexpr
+
+type cfn_decl = {
+  cfname      : string;
+  cret_typ    : ctyp;
+  cformals    : cbind list;
+  clocals     : cbind list;
+  cbody       : cstmt list;
+}
 
 type cstruct_def = Sast.sstruct_def
 

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -46,9 +46,7 @@ type slit =
   | SLitKn of slambda
   | SLitVector of sexpr list
   | SLitArray of sexpr list 
-  | SLitStruct of sstruct_field list
-
-and sstruct_field = SStructField of string * sexpr
+  | SLitStruct of (string * sexpr) list
 
 and sexpr =
   | SLit of styp * slit

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -63,7 +63,7 @@ and slambda = {
   slret_typ   : styp;
   slformals   : sbind list;
   slbody      : sexpr list;
-  sllocals    : sbind list; (* no lookback, const-ness not enforced *)
+  sllocals    : sbind list;         (* no lookback, const-ness not enforced *)
   slret_expr  : sexpr;
 }
 
@@ -79,9 +79,9 @@ type skn_decl = {
 type sgn_decl = {
   sgname      : string;
   sgret_typ   : styp;
-  sgformals   : sbind list;
-  sglocalvars : sbind list;         (* do not have lookback *)
+  sgformals   : (sbind * int) list;
   sglocalvals : (sbind * int) list; (* might have lookback *)
+  sglocalvars : sbind list;         (* do not have lookback *)
   sgbody      : sexpr list;
   sgret_expr  : sexpr;
 }


### PR DESCRIPTION
formals can also have lookback too, since they're just `val`s as well