### PR TITLE
Trees

### DIFF
--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -7,7 +7,10 @@ type styp =
   | SArray of styp
   | Void 
 
-type sbind = SBind of styp * string
+type sscope =
+  | Slocal | SGlobal
+
+type sbind = SBind of styp * string * sscope
 
 type sbin_op_i =
   | SAddi | SSubi | SMuli | SDivi | SMod | SExpi
@@ -50,7 +53,7 @@ type slit =
 
 and sexpr =
   | SLit of styp * slit
-  | SId of styp * string
+  | SId of styp * string * sscope
   | SBinop of styp * sexpr * sbin_op * sexpr
   | SAssign of styp * sexpr * sexpr
   | SKnCall of styp * string * sexpr list

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -4,7 +4,7 @@ type styp =
   | SString
   | SBool
   | SStruct of string
-  | SArray of styp
+  | SArray of styp * int option (* necessary for struct def'ns, not used elsewhere *)
   | Void 
 
 type sscope =

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -8,7 +8,7 @@ type styp =
   | Void 
 
 type sscope =
-  | SLocal | SGlobal
+  | SLocalVal | SLocalVar | SGlobal
 
 type sbind = SBind of styp * string
 

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -10,7 +10,7 @@ type styp =
 type sscope =
   | Slocal | SGlobal
 
-type sbind = SBind of styp * string * sscope
+type sbind = SBind of styp * string
 
 type sbin_op_i =
   | SAddi | SSubi | SMuli | SDivi | SMod | SExpi

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -64,8 +64,8 @@ and sexpr =
 and slambda = {
   slret_typ   : styp;
   slformals   : sbind list;
-  slbody      : (sexpr * styp) list;
   sllocals    : sbind list;         (* no lookback, const-ness not enforced *)
+  slbody      : (sexpr * styp) list;
   slret_expr  : (sexpr * styp);
 }
 

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -8,7 +8,7 @@ type styp =
   | Void 
 
 type sscope =
-  | Slocal | SGlobal
+  | SLocal | SGlobal
 
 type sbind = SBind of styp * string
 

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -64,9 +64,9 @@ and sexpr =
 and slambda = {
   slret_typ   : styp;
   slformals   : sbind list;
-  slbody      : sexpr list;
+  slbody      : (sexpr * styp) list;
   sllocals    : sbind list;         (* no lookback, const-ness not enforced *)
-  slret_expr  : sexpr;
+  slret_expr  : (sexpr * styp);
 }
 
 type skn_decl = {
@@ -74,8 +74,8 @@ type skn_decl = {
   skret_typ   : styp;
   skformals   : sbind list;
   sklocals    : sbind list;         (* do not have lookback *)
-  skbody      : sexpr list;
-  skret_expr  : sexpr;
+  skbody      : (sexpr * styp) list;
+  skret_expr  : (sexpr * styp);
 }
 
 type sgn_decl = {
@@ -84,8 +84,8 @@ type sgn_decl = {
   sgformals   : (sbind * int) list;
   sglocalvals : (sbind * int) list; (* might have lookback *)
   sglocalvars : sbind list;         (* do not have lookback *)
-  sgbody      : sexpr list;
-  sgret_expr  : sexpr;
+  sgbody      : (sexpr * styp) list;
+  sgret_expr  : (sexpr * styp);
 }
 
 type sfn_decl =

--- a/src/backend/sast.mli
+++ b/src/backend/sast.mli
@@ -47,7 +47,6 @@ type slit =
   | SLitBool of bool
   | SLitStr of string
   | SLitKn of slambda
-  | SLitVector of sexpr list
   | SLitArray of sexpr list 
   | SLitStruct of (string * sexpr) list
 


### PR DESCRIPTION
Added a few things here:

- Scoping indicator for `Id`, so that I can prefix things as appropriate
- fixed length arrays, which is necessary for struct definitions